### PR TITLE
Add installerscript & update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,21 +22,18 @@
 
 ### Installation
 
-- Clone the repo or download the script.
-- Navigate to the directory containing the script.
-- Run the script using python:
 ```bash
-python main.py
+bash <(wget -qO- https://raw.githubusercontent.com/NL-TCH/creamlinux-installer/refs/heads/main/installer.sh)
 ```
 
 ### Basic Usage
 - `--manual <path>`: Specify steam library path manually
 ```bash
-python main.py --manual "/path/to/steamapps"
+creamlinux-installer --manual "/path/to/steamapps"
 ```
 - `--debug`: Enable debug logging
 ```bash
-python main.py --debug
+creamlinux-installer --debug
 ```
 
 ### Issues?

--- a/installer.sh
+++ b/installer.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+REPO_URL="https://github.com/Novattz/creamlinux-installer.git"
+INSTALL_DIR="/opt/creamlinux-installer"
+WRAPPER_PATH="/usr/local/bin/creamlinux-installer"
+
+# Clone or update the repo
+if [ ! -d "$INSTALL_DIR" ]; then
+    echo "Cloning creamlinux-installer into $INSTALL_DIR..."
+    sudo git clone "$REPO_URL" "$INSTALL_DIR"
+else
+    echo "Repository already exists at $INSTALL_DIR."
+    echo "Pulling latest changes..."
+    cd "$INSTALL_DIR" && sudo git pull
+fi
+
+# Create or update the wrapper script
+echo "Creating/updating wrapper at $WRAPPER_PATH..."
+sudo tee "$WRAPPER_PATH" > /dev/null << EOF
+#!/bin/bash
+python3 $INSTALL_DIR/main.py "\$@"
+EOF
+
+# Make it executable
+sudo chmod +x "$WRAPPER_PATH"
+
+echo "✅ Done! You can now run 'creamlinux-installer' from anywhere."


### PR DESCRIPTION
Adds installerscript which let the program be installed with 1 command.
Installs the programm in a central location, so that the program (creamlinux-installer) can be run from any location
Updates the readme with the neccesary commands


```bash
$>  bash <(wget -qO- https://raw.githubusercontent.com/NL-TCH/creamlinux-installer/refs/heads/main/installer.sh)
Repository already exists at /opt/creamlinux-installer.
Pulling latest changes...
Already up to date.
Creating/updating wrapper at /usr/local/bin/creamlinux-installer...
✅ Done! You can now run 'creamlinux-installer' from anywhere.
```

Now you can run the programm from anywhere with `sudo creamlinux-installer`