### PR TITLE
Fix Nix impure evaluation problem and update README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ environment.systemPackages = [
   (pkgs.callPackage inputs.creamlinux-installer {})
 ];
 ```
+Similarly to running the AppImage, you will need to set `WEBKIT_DISABLE_DMABUF_RENDERER=1` if your GPU is from Nvidia in order to run the package.
 
 ### Building from Source
 

--- a/README.md
+++ b/README.md
@@ -82,10 +82,11 @@ npins add github Novattz creamlinux-installer --branch main
 ```nix
 let
   sources = import ./npins;
-  creamlinux = pkgs.callPackage sources.creamlinux-installer {};
 in
 {
-  environment.systemPackages = [ creamlinux ];
+  environment.systemPackages = [
+    (pkgs.callPackage "${sources.creamlinux-installer}/default.nix" {})
+  ];
 }
 ```
 Those are the recommended methods to add creamlinux-installer to your environment. However, you could also add it as an input of your flake, like so:

--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@
   src = ./.;
 
   patchSassEmbedded = pkgs.writeShellScriptBin "patch-sass-embedded" ''
-    NIX_LD="${pkgs.lib.fileContents "${pkgs.stdenv.cc}/nix-support/dynamic-linker"}"
+    NIX_LD="$(cat ${pkgs.stdenv.cc}/nix-support/dynamic-linker)"
     for dart_bin in node_modules/sass-embedded-linux-*/dart-sass/src/dart; do
       if [ -f "$dart_bin" ]; then
         ${pkgs.patchelf}/bin/patchelf --set-interpreter "$NIX_LD" "$dart_bin"


### PR DESCRIPTION
Hello again !
While trying to build the package at home, I noticed that Nix didn't allow to use
`pkgs.lib.fileContents` to read the dynamic linker path at evaluation time in pure eval mode.
This PR replaces it with a `$(cat ...)` call in the bash script, which resolves the path at runtime instead. I've also updated the guide on how to install and run the package since it seems like the  `WEBKIT_DISABLE_DMABUF_RENDERER` envvar must be set to `1` to run the package on a machine with an Nvidia GPU.