### PR TITLE
Improve Nix packaging structure and update npm dependencies hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,32 +48,30 @@ While the core functionality is working, please be aware that this is an early r
    ```
 
 ### Nix
-You can fetch this repository in your configuration using `pkgs.fetchFromGithub`:
+You can add this package to your configuration using `pkgs.fetchFromGitHub`:
 ```nix
 let
-  creamlinux = pkgs.callPackage (pkgs.fetchFromGitHub {
+  creamlinux = import (pkgs.fetchFromGitHub {
     owner = "Novattz";
     repo = "creamlinux-installer";
-    rev = "main";
-    hash = ""; # You can use nix-prefetch-url to determine which value to put here, or paste the value returned by the error your rebuild will output
-  }) {};
+    rev = "main"; # replace with a commit hash to pin the version
+    hash = ""; # paste the value returned by the error your rebuild will output
+  }) { inherit pkgs; };
 in
 {
   environment.systemPackages = [ creamlinux ];
-}  
+}
 ```
 or, using `builtins.fetchTarball`:
 ```nix
 let
-  creamlinux-src = builtins.fetchTarball {
+  creamlinux = import (builtins.fetchTarball {
     url = "https://github.com/Novattz/creamlinux-installer/archive/main.tar.gz";
     sha256 = ""; # See above
-  };
+  }) { inherit pkgs; };
 in
 {
-  environment.systemPackages = [
-    (pkgs.callPackage creamlinux-src {})
-  ];
+  environment.systemPackages = [ creamlinux ];
 }
 ```
 alternatively and if you want to pin the package version, using [npins](https://github.com/andir/npins):
@@ -86,12 +84,11 @@ let
 in
 {
   environment.systemPackages = [
-    (pkgs.callPackage "${sources.creamlinux-installer}/default.nix" {})
+    (import sources.creamlinux-installer { inherit pkgs; })
   ];
 }
 ```
 Those are the recommended methods to add creamlinux-installer to your environment. However, you could also add it as an input of your flake, like so:
-
 ```nix
 {
   inputs = {
@@ -108,7 +105,7 @@ Those are the recommended methods to add creamlinux-installer to your environmen
 Then, in your configuration:
 ```nix
 environment.systemPackages = [
-  (pkgs.callPackage inputs.creamlinux-installer {})
+  (import inputs.creamlinux-installer { inherit pkgs; })
 ];
 ```
 Similarly to running the AppImage, you will need to set `WEBKIT_DISABLE_DMABUF_RENDERER=1` if your GPU is from Nvidia in order to run the package.

--- a/default.nix
+++ b/default.nix
@@ -1,57 +1,7 @@
-{pkgs ? import <nixpkgs> {}}: let
-  cargoRoot = "src-tauri";
-  src = ./.;
-
-  patchSassEmbedded = pkgs.writeShellScriptBin "patch-sass-embedded" ''
-    NIX_LD="$(cat ${pkgs.stdenv.cc}/nix-support/dynamic-linker)"
-    for dart_bin in node_modules/sass-embedded-linux-*/dart-sass/src/dart; do
-      if [ -f "$dart_bin" ]; then
-        ${pkgs.patchelf}/bin/patchelf --set-interpreter "$NIX_LD" "$dart_bin"
-      fi
-    done
-  '';
-in
-  pkgs.rustPlatform.buildRustPackage {
-    pname = "creamlinux-installer";
-    version = "1.5.0-unstable-2026-04-23";
-    inherit src;
-
-    cargoLock.lockFile = ./src-tauri/Cargo.lock;
-
-    npmDeps = pkgs.fetchNpmDeps {
-      inherit src;
-      hash = "sha256-anYTERlnfOGDsGW0joy+h7wECJNDy6q+0a2to6t36pg=";
-    };
-
-    nativeBuildInputs =
-      [
-        pkgs.cargo-tauri.hook
-        pkgs.nodejs
-        pkgs.npmHooks.npmConfigHook
-        pkgs.pkg-config
-      ]
-      ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
-        pkgs.wrapGAppsHook4
-      ];
-
-    buildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [
-      pkgs.glib-networking
-      pkgs.openssl
-      pkgs.webkitgtk_4_1
-    ];
-
-    inherit cargoRoot;
-
-    buildAndTestSubdir = cargoRoot;
-
-    postPatch = ''
-      substituteInPlace src-tauri/tauri.conf.json \
-        --replace-fail '"createUpdaterArtifacts": true' '"createUpdaterArtifacts": false'
-    '';
-
-    preBuild = ''
-      ${patchSassEmbedded}/bin/patch-sass-embedded
-    '';
-
-    env.NO_STRIP = true;
-  }
+{
+  pkgs ?
+    import
+      (fetchTarball "https://github.com/NixOS/nixpkgs/archive/c6d65881c5624c9cae5ea6cedef24699b0c0a4c0.tar.gz")
+      { },
+}:
+pkgs.callPackage ./package.nix { }

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,72 @@
+{
+  cargo-tauri,
+  writeShellScriptBin,
+  stdenv,
+  patchelf,
+  rustPlatform,
+  fetchNpmDeps,
+  nodejs,
+  npmHooks,
+  pkg-config,
+  lib,
+  wrapGAppsHook4,
+  glib-networking,
+  openssl,
+  webkitgtk_4_1,
+}:
+let
+  cargoRoot = "src-tauri";
+  src = ./.;
+
+  patchSassEmbedded = writeShellScriptBin "patch-sass-embedded" ''
+    NIX_LD="$(cat ${stdenv.cc}/nix-support/dynamic-linker)"
+    for dart_bin in node_modules/sass-embedded-linux-*/dart-sass/src/dart; do
+      if [ -f "$dart_bin" ]; then
+        ${patchelf}/bin/patchelf --set-interpreter "$NIX_LD" "$dart_bin"
+      fi
+    done
+  '';
+in
+rustPlatform.buildRustPackage {
+  pname = "creamlinux-installer";
+  version = "1.5.5-unstable-2026-05-03";
+  inherit src;
+
+  cargoLock.lockFile = ./src-tauri/Cargo.lock;
+
+  npmDeps = fetchNpmDeps {
+    inherit src;
+    hash = "sha256-9VUywt71u4kuHNCFxW2aiavqM7e6tvBMHyzeSdJIJ5o=";
+  };
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    nodejs
+    npmHooks.npmConfigHook
+    pkg-config
+  ]
+  ++ lib.optionals stdenv.isLinux [
+    wrapGAppsHook4
+  ];
+
+  buildInputs = lib.optionals stdenv.isLinux [
+    glib-networking
+    openssl
+    webkitgtk_4_1
+  ];
+
+  inherit cargoRoot;
+
+  buildAndTestSubdir = cargoRoot;
+
+  postPatch = ''
+    substituteInPlace src-tauri/tauri.conf.json \
+      --replace-fail '"createUpdaterArtifacts": true' '"createUpdaterArtifacts": false'
+  '';
+
+  preBuild = ''
+    ${patchSassEmbedded}/bin/patch-sass-embedded
+  '';
+
+  env.NO_STRIP = true;
+}


### PR DESCRIPTION
Hello ! 

As the npm dependencies for the project were updated, I have to also update the hash for Nix. I took the opportunity to improve the structure of the Nix packaging while changing the `default.nix` ; the derivation has been moved to `package.nix`, which follows the standard nixpkgs convention, and `default.nix` is now a thin wrapper that simply calls it, making `nix-build` work out of the box and simplifying the import for users (no more `callPackage`, just `import ... { inherit pkgs; }`). I've updated the Readme to match the new structure as well.

I also wanted to say, whenever you update your npm dependencies, the hash in  `package.nix` must be updated as well, and Cargo dependencies don't require this in our case. Here's how to do it:

To get the new hash, set it to an empty string in `package.nix`:
```nix
  npmDeps = fetchNpmDeps {
    inherit src;
    hash = ""; # here
  };

```
Then run `nix-build`. The build will fail but Nix will print the correct hash in the error output:
```
got: sha256-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=
```
Just copy that value and replace the empty string with it.