### PR TITLE
Automate NPM hash fetch

### DIFF
--- a/.github/workflows/update-npm-hash.yml
+++ b/.github/workflows/update-npm-hash.yml
@@ -1,0 +1,31 @@
+name: Update npm deps hash
+
+on:
+  push:
+    paths:
+      - "package-lock.json"
+
+jobs:
+  update-hash:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Update hash
+        run: ./update-npm-hash.sh
+
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.nix
+          if [[ $(git status -s) ]]; then
+            git commit -m "chore: update npm deps hash"
+            git push
+          else
+            echo "Hash wasn't changed"
+          fi

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,4 @@
 {
-  pkgs ?
-    import
-      (fetchTarball "https://github.com/NixOS/nixpkgs/archive/c6d65881c5624c9cae5ea6cedef24699b0c0a4c0.tar.gz")
-      { },
+  pkgs ? import <nixpkgs> { },
 }:
 pkgs.callPackage ./package.nix { }

--- a/update-npm-hash.sh
+++ b/update-npm-hash.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-hash=$(nix-shell -p prefetch-npm-deps --run "prefetch-npm-deps package-lock.json" 2>/dev/null)
-echo "New hash: $hash"
-sed -i "s|hash = \"[^\"]*\"|hash = \"$hash\"|" package.nix

--- a/update-npm-hash.sh
+++ b/update-npm-hash.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+hash=$(nix-shell -p prefetch-npm-deps --run "prefetch-npm-deps package-lock.json" 2>/dev/null)
+echo "New hash: $hash"
+sed -i "s|hash = \"[^\"]*\"|hash = \"$hash\"|" package.nix


### PR DESCRIPTION
Hello again ! 

After our conversation on #113, I've [looked around a bit](https://sitr.us/2024/03/08/nix-npm-and-dependabot.html/), went ahead and implemented it for this repository ! I've tested it on my fork and the Github workflow is working as intended.

I've also changed the way to pass around `pkgs` to the `default.nix` ; instead of fetching a pinned version of nixpkgs when it's not passed to the function, which could lead uninformed users to have at least two versions of nixpkgs on their system, I instead try to look it up, something which is forbidden in pure evaluation mode and that should error out in most cases.